### PR TITLE
update cosign init to 'initialize'

### DIFF
--- a/docs/cli/sign.md
+++ b/docs/cli/sign.md
@@ -27,7 +27,7 @@ Login Succeeded
 Initialize `cosign` and create a key pair:
 
 ```bash
-$ cosign init
+$ cosign initialize
 $ cosign generate-key-pair
 cosign generate-key-pair
 Enter password for private key: Enter again:


### PR DESCRIPTION
I noticed the command `cosign init` returns an error.  Looks like we want `cosign initialize`.
```
❯ cosign init
Error: unknown command "init" for "cosign"

Did you mean this?
	initialize

Run 'cosign --help' for usage.
main.go:46: error during command execution: unknown command "init" for "cosign"

Did you mean this?
	initialize

❯ cosign version
  ______   ______        _______. __    _______ .__   __.
 /      | /  __  \      /       ||  |  /  _____||  \ |  |
|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
 \______| \______/  |_______/    |__|  \______| |__| \__|
cosign: A tool for Container Signing, Verification and Storage in an OCI registry.

GitVersion:    1.7.1
GitCommit:     53c28e44f10548c8839d4c72e5909fa74e08b5f6
GitTreeState:  "clean"
BuildDate:     2022-04-05T17:32:34Z
GoVersion:     go1.18
Compiler:      gc
Platform:      darwin/arm64