### PR TITLE
OPA and Topaz config docs

### DIFF
--- a/docs/opa.md
+++ b/docs/opa.md
@@ -1,0 +1,53 @@
+---
+sidebar_label: OPA Config
+---
+
+# Referencing an image from OPA Config
+
+:::note
+The [OPA docs](https://www.openpolicyagent.org/docs/latest/configuration/#using-private-image-from-oci-repositories) are the definitive source for how to configure OPA to download OCI images.
+:::
+
+## Example: ghcr.io
+
+To set up `ghcr.io` as an [OPA service](https://www.openpolicyagent.org/docs/latest/configuration/#example-1), you can use the following OPA config:
+
+```yaml
+services:
+  ghcr-registry:
+    url: https://ghcr.io
+    type: oci
+
+bundles:
+  authz:
+    service: ghcr-registry
+    resource: ghcr.io/${ORGANIZATION}/${REPOSITORY}:${TAG}
+    persist: true
+    polling:
+      min_delay_seconds: 60
+      max_delay_seconds: 120
+
+persistence_directory: ${PERSISTENCE_PATH}
+```
+
+To access private images, you'll need to provide credentials for the `ghcr-registry` service:
+
+```yaml
+services:
+  ghcr-registry:
+    url: https://ghcr.io
+    type: oci
+    credentials:
+      bearer:
+        scheme: "Bearer"
+        token: "<PAT>"
+```
+
+For registries that only support basic authentication, you can pass the credentials as follows:
+
+```yaml
+    credentials:
+      bearer:
+        scheme: "Basic"
+        token: "<username>:<password>"
+```

--- a/docs/topaz.md
+++ b/docs/topaz.md
@@ -27,7 +27,7 @@ opa:
         response_header_timeout_seconds: 5
         credentials:
           bearer:
-            schema: "Basic"
+            scheme: "Basic"
             token: "iDog"
     bundles:
       policy-todo:
@@ -57,7 +57,7 @@ opa:
         response_header_timeout_seconds: 5
         credentials:
           bearer:
-            schema: "Bearer"
+            scheme: "Bearer"
             token: "<PAT>"
     bundles:
       policy-todo:

--- a/docs/topaz.md
+++ b/docs/topaz.md
@@ -1,0 +1,80 @@
+---
+sidebar_label: Topaz Config
+---
+
+# Referencing an image from Topaz Config
+
+[Topaz](https://topaz.sh) uses OPA as a library, so configuring Topaz to download an OCI image works exactly the same way as it does for OPA.
+
+For Topaz, the OPA configuration is placed in a `opa:` section in the Topaz config file.
+
+## Example: ghcr.io
+
+To set up `ghcr.io` as the source for the policy image that Topaz will retrieve, you can use the following Topaz config:
+
+```yaml
+opa:
+  instance_id: "-"
+  graceful_shutdown_period_seconds: 2
+  local_bundles:
+    paths: []
+    skip_verification: true
+  config:
+    services:
+      ghcr-registry:
+        url: https://ghcr.io
+        type: oci
+        response_header_timeout_seconds: 5
+        credentials:
+          bearer:
+            schema: "Basic"
+            token: "iDog"
+    bundles:
+      policy-todo:
+        service: ghcr-registry
+        resource: "ghcr.io/aserto-templates/policy-todo-rebac:latest"
+        persist: false
+        config:
+          polling:
+            min_delay_seconds: 60
+            max_delay_seconds: 120
+```
+
+To access private images, you'll need to provide credentials for the `ghcr-registry` service:
+
+```yaml
+opa:
+  instance_id: "-"
+  graceful_shutdown_period_seconds: 2
+  local_bundles:
+    paths: []
+    skip_verification: true
+  config:
+    services:
+      ghcr-registry:
+        url: https://ghcr.io
+        type: oci
+        response_header_timeout_seconds: 5
+        credentials:
+          bearer:
+            schema: "Bearer"
+            token: "<PAT>"
+    bundles:
+      policy-todo:
+        service: ghcr-registry
+        resource: ghcr.io/${ORGANIZATION}/${REPOSITORY}:${TAG}
+        persist: false
+        config:
+          polling:
+            min_delay_seconds: 60
+            max_delay_seconds: 120
+```
+
+For registries that only support basic authentication, you can pass the credentials as follows:
+
+```yaml
+    credentials:
+      bearer:
+        scheme: "Basic"
+        token: "<username>:<password>"
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -6,6 +6,8 @@ module.exports = {
   sidebar: [
     'intro',
     'tutorial',
+    'opa',
+    'topaz',
     {
       type: 'category',
       label: 'CLI Reference',


### PR DESCRIPTION
Signed-off-by: Omri Gazitt <ogazitt@gmail.com>

Added docs for configuring OPA and Topaz with an OCI image. Examples sourced from ghcr.io.
