### PR TITLE
added a pointer to the Topaz configuration docs

### DIFF
--- a/docs/topaz.md
+++ b/docs/topaz.md
@@ -74,3 +74,5 @@ For registries that only support basic authentication, you can pass the credenti
         scheme: "Basic"
         token: "<username>:<password>"
 ```
+
+For more information on how to configure Topaz with a private policy image, refer to the Topaz [configuration](https://www.topaz.sh/docs/policies/configuration) docs.


### PR DESCRIPTION
This PR adds a pointer from the Topaz configuration section to the Topaz config docs.

It should be merged after https://github.com/aserto-dev/topaz-website/pull/115/files.
